### PR TITLE
Improve layout and loadingtime

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,42 @@
+select {
+  all: unset;
+  cursor: pointer;
+}
+.loadingScreen {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  background-color: #0B0D19;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1;
+  transition: ease 0.4s opacity;
+}
+
+.loader {
+  width: 100px;
+  aspect-ratio: 1;
+  display: grid;
+  border: 4px solid #0000;
+  border-radius: 50%;
+  border-right-color: #4ec07c;
+  animation: l15 1s infinite linear;
+}
+.loader::before,
+.loader::after {    
+  content: "";
+  grid-area: 1/1;
+  margin: 2px;
+  border: inherit;
+  border-radius: 50%;
+  animation: l15 2s infinite;
+}
+.loader::after {
+  margin: 8px;
+  animation-duration: 3s;
+}
+@keyframes l15{ 
+  100%{transform: rotate(1turn)}
+}

--- a/css/custom.css
+++ b/css/custom.css
@@ -40,3 +40,21 @@ select {
 @keyframes l15{ 
   100%{transform: rotate(1turn)}
 }
+
+.footer-links > li > a{
+    white-space: nowrap
+}
+@media (max-width: 740px) {
+    .footer-links {   
+        flex-direction: column;
+        text-align: right
+    }
+    .footer-links > li {
+        margin: 2px !important  /* play with the value until links are easy to tap on touch devices */
+    }
+}
+@media (max-width: 640px) {
+    .footer-links {   
+        text-align: center;
+    }
+}


### PR DESCRIPTION
Added additional css from line 43 to improve the display of links in the footer on mobile devices.

From a screen width of less than 740px, these are now displayed wrapped right below each other. If the display width is less than 640px, they are also centred.

closes #5 